### PR TITLE
chore(web-standard): fix error message

### DIFF
--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -193,7 +193,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 	listen() {
 		return () => {
 			throw new Error(
-				'WebStandard does not support listen, you might want to export default Elysia.fetch instead'
+				'WebStandard does not support listen, you might want to export default Elysia.fetch instead\nIf you want to use listen in node, you can install @elysiajs/node'
 			)
 		}
 	}


### PR DESCRIPTION
## purpose

If no specific settings are configured, it defaults to bun or WebStandard.
In a Node environment, if users skip the tutorial, they will likely encounter errors showing modified locations,
but these errors don't contain the information users actually need.
While it's partly the users' fault for not reading the tutorial, I believe that as an error message, it should provide the information users are looking for.